### PR TITLE
feat: Filtrado por múltiples ubicaciones en get_my_pases

### DIFF
--- a/lkf_addons/addons/accesos/app.py
+++ b/lkf_addons/addons/accesos/app.py
@@ -5228,7 +5228,7 @@ class Accesos(AccesosModel):
                         res.append(r['perfil'])
         return res
     
-    def get_my_pases(self, tab_status, limit=10, skip=0, search_name=None, location=None, dynamic_filters=[], dateFrom="", dateTo="", filterDate=""):
+    def get_my_pases(self, tab_status, limit=10, skip=0, search_name=None, location=None, dynamic_filters=[], dateFrom="", dateTo="", filterDate="", locations=[]):
         employee = self.get_employee_data(user_id=self.user.get('user_id'), get_one=True)
         fecha_hoy = datetime.now(pytz.timezone(self.user['timezone'])).replace(microsecond=0).astimezone(pytz.utc).replace(tzinfo=None)
         fecha_hoy_formateada = fecha_hoy.strftime('%Y-%m-%d %H:%M:%S')
@@ -5263,7 +5263,9 @@ class Accesos(AccesosModel):
                 ]
             })
         if location:
-            match_query.update({f"answers.{self.mf['grupo_ubicaciones_pase']}.{self.UBICACIONES_CAT_OBJ_ID}.{self.f['location']}": location})
+            match_query[f"answers.{self.mf['grupo_ubicaciones_pase']}.{self.UBICACIONES_CAT_OBJ_ID}.{self.f['location']}"] = location
+        if locations:
+            match_query[f"answers.{self.mf['grupo_ubicaciones_pase']}.{self.UBICACIONES_CAT_OBJ_ID}.{self.f['location']}"] = {"$in": locations}
         if dynamic_filters:
             for item in dynamic_filters:
                 if item.get('key') == 'status':


### PR DESCRIPTION
## ¿Qué cambia?

- Se agrega el parámetro `locations` (lista) a la función `get_my_pases`, permitiendo filtrar pases de entrada por múltiples ubicaciones simultáneamente.
- El filtro utiliza el operador `$in` de MongoDB para hacer coincidir cualquiera de las ubicaciones proporcionadas.
- Se refactoriza la asignación del filtro de `location` individual para usar asignación directa en lugar de `.update()`, manteniendo consistencia con el nuevo filtro.

## ¿Por qué?

Antes solo era posible filtrar los pases de entrada por una única ubicación a la vez. Esta limitación impedía consultas más amplias cuando el usuario tiene acceso a múltiples ubicaciones o necesita visualizar pases de varias de ellas en una sola llamada.

## Notas adicionales

- Los parámetros `location` y `locations` son independientes: si se proveen ambos, `locations` sobreescribe el valor del campo en la query. Se recomienda usar solo uno a la vez para evitar comportamientos inesperados.
- El parámetro `locations` espera una lista de strings con los IDs de ubicación.