### PR TITLE
feat: tipos aceptados y soporte slider en esquema de inspecciones de rondín

### DIFF
--- a/lkf_addons/addons/accesos/app.py
+++ b/lkf_addons/addons/accesos/app.py
@@ -8963,16 +8963,30 @@ class Accesos(AccesosModel):
 
         questions = []
         for field in fields:
+            field_type = field.get('field_type')
+            if field_type not in self.INSPECTION_ACCEPTED_TYPES:
+                continue
+
+            question_schema = {}
             options = field.get('options', [])
-            question_schema = {
+            if field_type == 'integer':
+                field_properties = field.get('properties', {})
+                field_min = field_properties.get('min')
+                field_max = field_properties.get('max')
+                if field_min or field_max:
+                    field_type = 'slider'
+                    question_schema['min'] = field_min or 0
+                    question_schema['max'] = field_max or field_min + 100
+
+            question_schema.update({
                 'pregunta': field.get('label', ''),
-                'tipo': field.get('field_type',''),
+                'tipo': field_type,
                 'opciones': [opt.get('label') for opt in options if opt.get('label')],
                 'required': field.get('required', False),
-                'valor':"",
-                'comentario':"",
-                'foto':None,
-            }
+                'valor': "",
+                'comentario': "",
+                'foto': None,
+            })
             questions.append(question_schema)
 
         return questions

--- a/lkf_addons/addons/accesos/model.py
+++ b/lkf_addons/addons/accesos/model.py
@@ -895,3 +895,5 @@ class AccesosModel(Employee, Location, Vehiculo, Base):
             'llamar_num_alerta': '695d36605f78faab793f497d',
             'email_alerta': '695d36605f78faab793f497e'
         })
+
+        self.INSPECTION_ACCEPTED_TYPES = ['radio', 'checkbox', 'decimal', 'integer', 'text', 'slider']


### PR DESCRIPTION
## ¿Qué cambia?

- Se define la constante `INSPECTION_ACCEPTED_TYPES` en el modelo con los tipos válidos: `radio`, `checkbox`, `decimal`, `integer`, `text`, `slider`.
- Al construir el esquema de preguntas de inspección, los campos cuyo `field_type` no esté en la lista de tipos aceptados son ignorados.
- Los campos de tipo `integer` que contengan propiedades `min` y/o `max` se tratan como tipo `slider`, incluyendo esos valores en el esquema de la pregunta.

## ¿Por qué?

Anteriormente, todos los campos del formulario importado se incluían en el esquema de inspección sin importar su tipo, lo que podía generar preguntas con tipos incompatibles o sin soporte en el rondín. Con este cambio se garantiza que solo se consideren los tipos que la aplicación puede manejar correctamente, y se aprovecha la semántica del `slider` para enteros con rango definido.

## Notas adicionales

- Si un campo `integer` tiene solo `min` o solo `max`, el valor faltante se calcula como `0` (para `min`) o `min + 100` (para `max`) como valor por defecto.
- El filtrado es silencioso: los campos no aceptados simplemente se omiten sin lanzar error.