### PR TITLE
Agregar field_id e inspeccion_form_id al registro inbox de rondín

### DIFF
--- a/lkf_addons/addons/accesos/app.py
+++ b/lkf_addons/addons/accesos/app.py
@@ -8980,12 +8980,10 @@ class Accesos(AccesosModel):
 
             question_schema.update({
                 'pregunta': field.get('label', ''),
+                'field_id': field.get('field_id', ''),
                 'tipo': field_type,
                 'opciones': [opt.get('label') for opt in options if opt.get('label')],
                 'required': field.get('required', False),
-                'valor': "",
-                'comentario': "",
-                'foto': None,
             })
             questions.append(question_schema)
 
@@ -9033,6 +9031,7 @@ class Accesos(AccesosModel):
         for i in format_check_areas:
             form_id = inpections_by_area['areas'].get(i['area'])
             i['inspeccion'] = inpections_by_area['inspection_ids'].get(form_id, {})
+            i['inspeccion_form_id'] = form_id
             i['checked'] = False
             i['checked_at'] = ''
             i['check_area_id'] = ''


### PR DESCRIPTION
## ¿Qué cambia?

- Se agrega el campo `field_id` al esquema de cada pregunta de inspección, tomándolo directamente del campo `field_id` del formulario fuente.
- Se agrega el campo `inspeccion_form_id` a cada área del formato de verificación (`format_check_areas`), almacenando el `form_id` de la inspección asociada.
- Se eliminan los campos `valor`, `comentario` y `foto` del esquema base de pregunta, ya que estos valores no deben inicializarse en el registro de inbox.

## ¿Por qué?

El registro de inbox en CouchDB para rondín necesita los identificadores de campo y de formulario de inspección para poder correlacionar correctamente las respuestas con sus definiciones de origen. Sin `field_id`, no era posible vincular una respuesta al campo específico del formulario; sin `inspeccion_form_id`, se perdía la referencia al formulario de inspección por área.

## Notas adicionales

- La eliminación de `valor`, `comentario` y `foto` del esquema base implica un cambio en la estructura del documento guardado en CouchDB; verificar que los consumidores de estos registros no dependan de la presencia de esas claves vacías.