### PR TITLE
Inyectar imágenes y comentarios en inspección directo en BD

### DIFF
--- a/lkf_addons/addons/accesos/app.py
+++ b/lkf_addons/addons/accesos/app.py
@@ -9131,6 +9131,8 @@ class Accesos(OcrMixin, AccesosModel):
             response_inspeccion = self.create_inspeccion(complete_record, inspeccion_form_id)
             inspeccion_id = response_inspeccion.get('json', {}).get('id', '')
             complete_record['record']['inspeccion_record_id'] = inspeccion_id
+            #TODO: EN CASO DE ERROR QUE SUCEDE?
+            self.insert_images_and_comments_into_inspeccion(complete_record, inspeccion_form_id, inspeccion_id)
         response = self.create_check_area(complete_record)
         print('response del check de area', response)
         if response.get('status_code') in [200, 201, 202, 208,]:
@@ -9861,6 +9863,45 @@ class Accesos(OcrMixin, AccesosModel):
         metadata.update({'answers':answers})
         res = self.lkf_api.post_forms_answers(metadata)
         return res
+
+    def insert_images_and_comments_into_inspeccion(self, record, form_id, record_id):
+        """
+        Insert images and comments into inspeccion
+        """
+        images = {}
+        comments = {}
+        data = record.get('record', {})
+        inspection = data.get('inspeccion', [])
+        for question in inspection:
+            if question.get('field_id'):
+                if question.get('foto'):
+                    images.update({
+                        question.get('field_id'): question.get('foto')
+                    })
+                if question.get('comentario'):
+                    comments.update({
+                        question.get('field_id'): question.get('comentario')
+                    })
+
+        if not images and not comments:
+            return False
+            
+        update_fields = {
+            "images": images,
+            "comments": comments
+        }
+        update_db = self.cr.update_one({
+            '_id': ObjectId(record_id),
+            'form_id': form_id,
+            'deleted_at': {'$exists': False}
+        },{'$set':update_fields})
+
+        db_res = update_db.raw_result
+        print('db_res_inspeccion=',db_res)
+        update_ok = db_res.get('updatedExisting')
+        if update_ok:
+            return True
+        return False
     
     def delete_rondines(self, records):
         status = {}


### PR DESCRIPTION
## ¿Qué cambia?

- Se agrega el método `insert_images_and_comments_into_inspeccion` que, una vez creado el registro de inspección, actualiza directamente en MongoDB los campos `images` y `comments`.
- El método extrae fotos y comentarios de cada pregunta de la inspección (`record.inspeccion[]`) y los agrupa por `field_id`.
- La actualización se realiza con `update_one` filtrando por `_id`, `form_id` y documentos no eliminados (`deleted_at` inexistente).
- Se llama automáticamente dentro del flujo de `check_area` justo después de obtener el `inspeccion_id`.

## ¿Por qué?

El registro de inspección se crea primero vía la API de LinkaForm, pero las imágenes y comentarios asociados a cada pregunta necesitan ser persistidos de forma directa en la base de datos, ya que no forman parte del payload inicial de creación. Esta separación permite mantener el flujo de creación limpio y delegar la inyección de media como un paso posterior controlado.

## Notas adicionales

- Existe un `TODO` en el punto de llamada: aún no se maneja el caso de error cuando `insert_images_and_comments_into_inspeccion` falla; se debe definir si se revierte el registro o se registra el error sin interrumpir el flujo.
- Si no hay imágenes ni comentarios que insertar, el método retorna `False` sin realizar ninguna operación en BD.