### PR TITLE
feat(accesos): OCR Paquetería – análisis de empleados y proveedores de paquetería

### DIFF
--- a/lkf_addons/addons/accesos/app.py
+++ b/lkf_addons/addons/accesos/app.py
@@ -78,6 +78,26 @@ class Accesos(OcrMixin, AccesosModel):
         weak “internal use” indicator. E.g. from M import * does not import objects whose names start with an underscore.
     '''
 
+    def get_mongo_string_list(func):
+        def wrapper(self, *args, **kwargs):
+            config = func(self, *args, **kwargs)
+            match_query_custom = config.get('query', {})
+            form_id = config.get('form_id')
+            project_fields = config.get('project', {})
+            match_query = {"deleted_at": {"$exists": False}}
+            if form_id:
+                match_query["form_id"] = form_id
+            match_query.update(match_query_custom)
+            query = [{"$match": match_query}, {"$project": {"_id": 0, **project_fields}}]
+            data = self.format_cr(self.cr.aggregate(query))
+            format_data = []
+            if data:
+                for item in data:
+                    format_data.append(item.get("value"))
+                format_data = list(set(format_data))
+            return format_data
+        return wrapper
+
     def _do_access(self, access_pass, location, area, data):
         '''
         Registra el acceso del pase de entrada a ubicación.
@@ -4122,6 +4142,15 @@ class Accesos(OcrMixin, AccesosModel):
     def get_ids_labels(self, data):
         return data
 
+    @get_mongo_string_list
+    def get_employees_names(self):
+        return {
+            "form_id": self.EMPLEADOS,
+            "project": {
+                "value": f"$answers.{self.mf['nombre_empleado']}"
+            }
+        } 
+
     def get_employees_data(self, names=None, user_id=None, username=None, email=None,  get_one=False):
         match_query = {
             "deleted_at":{"$exists":False},
@@ -5230,6 +5259,22 @@ class Accesos(OcrMixin, AccesosModel):
                     if r['perfil'] not in res:
                         res.append(r['perfil'])
         return res
+
+    def get_proveedores_paqueteria(self):
+        """
+        Obtiene los proveedores de paquetería del catalogo de PROVEEDORES DE PAQUETERIA.
+        """
+        selector = {}
+        mango_query = {
+            "selector": selector,
+            "limit": 10000,
+        }
+        data = self.lkf_api.search_catalog(self.PROVEEDORES_DE_PAQUETERIA_CAT_ID, mango_query)
+        format_data = []
+        if data:
+            format_data = {i.get(self.f['proveedor_de_paqueteria']) for i in data}
+            format_data = list(format_data)
+        return format_data
     
     def get_my_pases(self, tab_status, limit=10, skip=0, search_name=None, location=None, dynamic_filters=[], dateFrom="", dateTo="", filterDate="", locations=[]):
         employee = self.get_employee_data(user_id=self.user.get('user_id'), get_one=True)
@@ -8430,6 +8475,16 @@ class Accesos(OcrMixin, AccesosModel):
         metadata.update({'answers': answers})
         sms_response = self.lkf_api.post_forms_answers(metadata)
         return sms_response
+
+    def create_proveedor_de_paqueteria(self, proveedor):
+        answers = {}
+        catalogo_metadata = self.lkf_api.get_catalog_metadata(catalog_id=self.PROVEEDORES_DE_PAQUETERIA_CAT_ID)
+        answers[self.f['proveedor_de_paqueteria']] = proveedor
+        catalogo_metadata.update({'answers': answers})
+        res = self.lkf_api.post_catalog_answers(catalogo_metadata)
+        if res.get('status_code') not in [200, 201, 202]:
+            self.LKFException({"title": "Error en crear proveedor de paqueteria", "msg": "No se pudo crear correctamente el registro."})
+        return res
 
     def create_class_google_wallet(self, data, qr_code):
         ISSUER_ID = '3388000000022924601'

--- a/lkf_addons/addons/accesos/items/catalogs/Seguridad/proveedores_de_paqueteria.xml
+++ b/lkf_addons/addons/accesos/items/catalogs/Seguridad/proveedores_de_paqueteria.xml
@@ -1,0 +1,61 @@
+<?xml version='1.0' encoding='utf-8'?>
+<lkf>
+    <templates>[]</templates>
+    <confirmation>
+        <message>¡Su información fue capturada!</message>
+        <button_message>Mandar respuestas</button_message>
+        <redirect_url>default</redirect_url>
+    </confirmation>
+    <description />
+    <_rev>2-ebcc697de0bb98b0abb3514db6d0806e</_rev>
+    <updated_at>2026-05-27T21:40:14.695304+00:00Z</updated_at>
+    <sync>
+        <element_request>{}</element_request>
+        <input_parameters>[]</input_parameters>
+    </sync>
+    <filters>{}</filters>
+    <name>Proveedores de Paqueteria</name>
+    <edit_public_records>False</edit_public_records>
+    <created_at>2026-05-27T21:40:14.695304+00:00Z</created_at>
+    <advanced_options>
+        <active>True</active>
+        <folio>
+            <manual>False</manual>
+            <required>False</required>
+            <config>False</config>
+        </folio>
+    </advanced_options>
+    <catalog_pages>
+        <item>
+            <page_fields>
+                <item>
+                    <field_type>text</field_type>
+                    <properties>
+                        <send_email>False</send_email>
+                        <size>complete</size>
+                        <custom>None</custom>
+                    </properties>
+                    <key>None</key>
+                    <catalog_fields>[]</catalog_fields>
+                    <field_id>6a1764be5451b26d5de3152b</field_id>
+                    <required>False</required>
+                    <fav>None</fav>
+                    <related_catalog_key>[]</related_catalog_key>
+                    <relation_type>None</relation_type>
+                    <label>Nombre del Proveedor</label>
+                    <catalog>{}</catalog>
+                    <catalog_id>None</catalog_id>
+                    <view_fields>[]</view_fields>
+                    <options>[]</options>
+                    <related_catalog>None</related_catalog>
+                </item>
+            </page_fields>
+            <page_name>Página 1</page_name>
+            <page_description>None</page_description>
+        </item>
+    </catalog_pages>
+    <sync_last_update>None</sync_last_update>
+    <_id>6a1764be5451b26d5de3152a</_id>
+    <public>False</public>
+    <catalog_id>154292</catalog_id>
+</lkf>

--- a/lkf_addons/addons/accesos/model.py
+++ b/lkf_addons/addons/accesos/model.py
@@ -143,6 +143,10 @@ class AccesosModel(Employee, Location, Vehiculo, Base):
         self.PROVEEDORES_CAT_ID = self.PROVEEDORES_CAT.get('id')
         self.PROVEEDORES_CAT_OBJ_ID = self.PROVEEDORES_CAT.get('obj_id')
 
+        self.PROVEEDORES_DE_PAQUETERIA_CAT = self.lkm.catalog_id('proveedores_de_paqueteria')
+        self.PROVEEDORES_DE_PAQUETERIA_CAT_ID = self.PROVEEDORES_CAT.get('id')
+        self.PROVEEDORES_DE_PAQUETERIA_CAT_OBJ_ID = self.PROVEEDORES_CAT.get('obj_id')
+
         self.load(module='Employee', **self.kwargs)
 
         # self.CONF_PERFIL = self.lkm.catalog_id('configuracion_de_perfiles','id')
@@ -894,7 +898,8 @@ class AccesosModel(Employee, Location, Vehiculo, Base):
             'accion_alerta': '695d36605f78faab793f497c',
             'llamar_num_alerta': '695d36605f78faab793f497d',
             'email_alerta': '695d36605f78faab793f497e',
-            'url_inspeccion': '6a0c8ab354a0b8de897c62cc'
+            'url_inspeccion': '6a0c8ab354a0b8de897c62cc',
+            'proveedor_de_paqueteria': '6a1764be5451b26d5de3152b'
         })
 
         self.INSPECTION_ACCEPTED_TYPES = ['radio', 'checkbox', 'decimal', 'integer', 'text', 'slider']

--- a/lkf_addons/tools/OcrMixin.py
+++ b/lkf_addons/tools/OcrMixin.py
@@ -98,6 +98,22 @@ class OcrMixin:
 
         datos = self._ocr_normalizar(datos)
 
+        # Se asigna nombre del remitente
+        nombre_remitente = datos.get('remitente', '')
+        empleados = self.get_employees_names()
+        match_empleado = self._match_label(nombre_remitente, empleados)
+        if match_empleado.get('label'):
+            datos['remitente'] = match_empleado['label']
+
+        # Se asigna nombre del proveedor de paqueteria
+        proveedores = self.get_proveedores_paqueteria()
+        proveedor = datos.get('paqueteria')
+        match_proveedor = self._match_label(proveedor, proveedores)
+        if not match_proveedor.get('label'):
+            self.create_proveedor_de_paqueteria(proveedor)
+        else:
+            datos['paqueteria'] = match_proveedor['label']
+
         # 3. Validar
         errores = self._ocr_validar_id(datos)
         if errores:
@@ -324,6 +340,40 @@ class OcrMixin:
     # ──────────────────────────────────────────────────────────
     # HELPERS PRIVADOS
     # ──────────────────────────────────────────────────────────
+
+    def _match_label(self, nombre: str, empleados: list, umbral: int = 75) -> dict:
+        """
+        Busca el empleado más parecido a `nombre` usando difflib.
+        Normaliza tildes y orden de palabras antes de comparar.
+
+        Returns:
+            {'empleado': str, 'score': int}  si supera el umbral
+            {'empleado': None, 'score': int}  si ninguno supera el umbral
+        """
+        import unicodedata
+        from difflib import SequenceMatcher
+
+        def normalizar(s):
+            s = unicodedata.normalize('NFD', s)
+            s = ''.join(c for c in s if unicodedata.category(c) != 'Mn')
+            return ' '.join(sorted(s.lower().split()))
+
+        nombre_norm = normalizar(nombre)
+        nombre_words = set(nombre_norm.split())
+        mejor, mejor_score = None, 0
+
+        for emp in empleados:
+            emp_norm = normalizar(emp)
+            emp_words = set(emp_norm.split())
+            seq_score = int(SequenceMatcher(None, nombre_norm, emp_norm).ratio() * 100)
+            word_score = int(len(nombre_words & emp_words) / len(nombre_words) * 100) if nombre_words else 0
+            score = max(seq_score, word_score)
+            if score > mejor_score:
+                mejor, mejor_score = emp, score
+
+        if mejor_score >= umbral:
+            return {'label': mejor, 'score': mejor_score}
+        return {'label': None, 'score': mejor_score}
 
     def _ocr_normalizar(self, datos: dict) -> dict:
         """Normaliza los datos extraídos. Código puro, sin LLM."""


### PR DESCRIPTION
## ¿Qué cambia?

- Se agrega el decorador `get_mongo_string_list` que abstrae consultas de agregación MongoDB y retorna listas de strings, reutilizable para distintos campos.
- Se agrega `get_employees_names()` para obtener los nombres de empleados registrados en el formulario `EMPLEADOS`, usado en el flujo OCR para identificar al remitente.
- Se agrega `get_proveedores_paqueteria()` para consultar los proveedores registrados en el catálogo **Proveedores de Paquetería**.
- Se agrega `create_proveedor_de_paqueteria(proveedor)` para crear un nuevo registro en dicho catálogo si el proveedor detectado por OCR no existe.
- Se incluye la definición XML del catálogo `proveedores_de_paqueteria` (catalog_id `154292`) con el campo *Nombre del Proveedor* (`field_id: 6a1764be5451b26d5de3152b`).
- En `model.py` se registran las constantes `PROVEEDORES_DE_PAQUETERIA_CAT_ID` / `_OBJ_ID` y se agrega la key `proveedor_de_paqueteria` al diccionario de field IDs.

## ¿Por qué?

El módulo OCR de Paquetería necesita contrastar los nombres detectados en la guía contra empleados reales del sistema y contra proveedores de paquetería conocidos (DHL, FedEx, etc.). Si el proveedor detectado no existe en el catálogo se crea automáticamente, evitando rechazos por datos no catalogados y enriqueciendo el catálogo de forma incremental.

## Notas adicionales

- El catálogo XML debe importarse en el ambiente correspondiente antes de ejecutar cualquier flujo que llame a `get_proveedores_paqueteria()` o `create_proveedor_de_paqueteria()`.