### PR TITLE
fix(ocr): soportar listas en funciones de normalización y validación OCR

### DIFF
--- a/lkf_addons/tools/OcrMixin.py
+++ b/lkf_addons/tools/OcrMixin.py
@@ -199,7 +199,8 @@ class OcrMixin:
                     'data': datos,
                 }
 
-        return {'status_code': datos.get('status_code', 200), 'msg': 'OK', 'data': datos}
+        status = 200 if isinstance(datos, list) else datos.get('status_code', 200)
+        return {'status_code': status, 'msg': 'OK', 'data': datos}
 
     # ──────────────────────────────────────────────────────────
     # OCR GENÉRICO
@@ -375,8 +376,10 @@ class OcrMixin:
             return {'label': mejor, 'score': mejor_score}
         return {'label': None, 'score': mejor_score}
 
-    def _ocr_normalizar(self, datos: dict) -> dict:
+    def _ocr_normalizar(self, datos):
         """Normaliza los datos extraídos. Código puro, sin LLM."""
+        if isinstance(datos, list):
+            return [self._ocr_normalizar(d) for d in datos]
         datos['nombre_completo'] = ""
         if datos.get('curp'):
             datos['curp'] = datos['curp'].upper().strip()
@@ -395,11 +398,13 @@ class OcrMixin:
             datos.pop('nombre_completo')
         return datos
 
-    def _ocr_validar_id(self, datos: dict) -> list:
+    def _ocr_validar_id(self, datos) -> list:
         """
         Validaciones deterministas de una ID. Código puro, sin LLM.
         Retorna lista de warnings (vacía = todo OK).
         """
+        if isinstance(datos, list):
+            return [w for d in datos for w in self._ocr_validar_id(d)]
         import re
         warnings = []
 


### PR DESCRIPTION
## ¿Qué cambia?

- `_ocr_normalizar` ahora acepta `list` o `dict`: si recibe una lista, aplica la normalización recursivamente a cada elemento y retorna una lista normalizada.
- `_ocr_validar_id` ahora acepta `list` o `dict`: si recibe una lista, agrega los warnings de cada elemento en una sola lista plana.
- La función que construye el response (línea ~199) ya no asume que `datos` es un diccionario al leer `status_code`; usa `200` como default cuando `datos` es una lista.

## ¿Por qué?

Algunos flujos OCR devuelven múltiples resultados en forma de lista (ej. documentos con varias páginas o múltiples IDs escaneadas). Las funciones anteriores asumían siempre un `dict` y lanzaban `AttributeError` al recibir una lista, rompiendo el procesamiento sin un mensaje de error claro.

## Notas adicionales

- Los cambios son retrocompatibles: cuando `datos` es un `dict`, el comportamiento es idéntico al anterior.
- Se eliminó la type hint estricta `datos: dict` en ambos métodos para reflejar que ahora aceptan tipos union (`dict | list`).