### PR TITLE
Refactor: proveedores de paquetería desde forma en lugar de catálogo

### DIFF
--- a/lkf_addons/addons/accesos/app.py
+++ b/lkf_addons/addons/accesos/app.py
@@ -5262,17 +5262,23 @@ class Accesos(OcrMixin, AccesosModel):
 
     def get_proveedores_paqueteria(self):
         """
-        Obtiene los proveedores de paquetería del catalogo de PROVEEDORES DE PAQUETERIA.
+        Obtiene los proveedores de paquetería de la FORMA de PROVEEDORES.
         """
-        selector = {}
-        mango_query = {
-            "selector": selector,
-            "limit": 10000,
-        }
-        data = self.lkf_api.search_catalog(self.PROVEEDORES_DE_PAQUETERIA_CAT_ID, mango_query)
+        query = [
+            {"$match": {
+                "deleted_at": {"$exists": False},
+                "form_id": self.PROVEEDORES_FORM,
+                f"answers.{self.f['tipo_de_proveedor']}": "paqueteria"
+            }},
+            {"$project": {
+                "_id": 0,
+                "nombre_proveedor": f"$answers.{self.f['nombre_comercial']}"
+            }}
+        ]
+        data = self.format_cr(self.cr.aggregate(query))
         format_data = []
         if data:
-            format_data = {i.get(self.f['proveedor_de_paqueteria']) for i in data}
+            format_data = {i.get('nombre_proveedor') for i in data}
             format_data = list(format_data)
         return format_data
     
@@ -8477,11 +8483,24 @@ class Accesos(OcrMixin, AccesosModel):
         return sms_response
 
     def create_proveedor_de_paqueteria(self, proveedor):
-        answers = {}
-        catalogo_metadata = self.lkf_api.get_catalog_metadata(catalog_id=self.PROVEEDORES_DE_PAQUETERIA_CAT_ID)
-        answers[self.f['proveedor_de_paqueteria']] = proveedor
-        catalogo_metadata.update({'answers': answers})
-        res = self.lkf_api.post_catalog_answers(catalogo_metadata)
+        metadata = self.lkf_api.get_metadata(form_id=self.PROVEEDORES_FORM)
+        metadata.update({
+            'properties': {
+                'device_properties': {
+                    'System': 'Script',
+                    'Module': 'Accesos',
+                    'Process': 'OCR Paqueteria',
+                    'Action': 'create_proveedor_de_paqueteria',
+                    'File': 'lkf_addons/addons/accesos/app.py',
+                }
+            },
+            'answers': {
+                self.f['nombre_comercial']: proveedor,
+                self.f['razon_social']: proveedor,
+                self.f['tipo_de_proveedor']: 'paqueteria',
+            }
+        })
+        res = self.lkf_api.post_forms_answers(metadata)
         if res.get('status_code') not in [200, 201, 202]:
             self.LKFException({"title": "Error en crear proveedor de paqueteria", "msg": "No se pudo crear correctamente el registro."})
         return res

--- a/lkf_addons/addons/accesos/model.py
+++ b/lkf_addons/addons/accesos/model.py
@@ -57,6 +57,7 @@ class AccesosModel(Employee, Location, Vehiculo, Base):
         self.CHECK_UBICACIONES = self.lkm.form_id('check_ubicaciones','id')
         self.REGISTRO_ASISTENCIA = self.lkm.form_id('registro_de_asistencia','id')
         self.FORMATO_VACACIONES = self.lkm.form_id('formato_vacaciones_aviso','id')
+        self.PROVEEDORES_FORM = self.lkm.form_id('proveedores','id')
 
         self.last_check_in = []
         # self.FORM_ALTA_COLABORADORES = self.lkm.form_id('alta_de_colaboradores_visitantes','id')
@@ -899,7 +900,8 @@ class AccesosModel(Employee, Location, Vehiculo, Base):
             'llamar_num_alerta': '695d36605f78faab793f497d',
             'email_alerta': '695d36605f78faab793f497e',
             'url_inspeccion': '6a0c8ab354a0b8de897c62cc',
-            'proveedor_de_paqueteria': '6a1764be5451b26d5de3152b'
+            'proveedor_de_paqueteria': '6a1764be5451b26d5de3152b',
+            'tipo_de_proveedor': '6a18e4086423e82150aa527c'
         })
 
         self.INSPECTION_ACCEPTED_TYPES = ['radio', 'checkbox', 'decimal', 'integer', 'text', 'slider']


### PR DESCRIPTION
## ¿Qué cambia?

- `get_proveedores_paqueteria()` deja de consultar el catálogo `PROVEEDORES_DE_PAQUETERIA_CAT_ID` y ahora ejecuta un aggregation de MongoDB directamente sobre la forma de Proveedores, filtrando por `tipo_de_proveedor == 'paqueteria'`.
- `create_proveedor_de_paqueteria()` deja de usar `post_catalog_answers` y ahora crea el registro con `post_forms_answers`, incluyendo `device_properties` y los campos `nombre_comercial`, `razon_social` y `tipo_de_proveedor`.
- Se agrega `PROVEEDORES_FORM` al modelo (`model.py`) resolviendo el ID de la forma `proveedores`.
- Se registra el field ID de `tipo_de_proveedor` (`6a18e4086423e82150aa527c`) en el dict `self.f`.

## ¿Por qué?

El flujo de OCR de paquetes requiere obtener y crear proveedores desde la forma de Proveedores en lugar del catálogo anterior, ya que la forma permite manejar el tipo de proveedor (`paqueteria`) como un campo estructurado y mantiene consistencia con el resto de los flujos de la plataforma.

## Notas adicionales

- La consulta de obtención usa `self.cr.aggregate` + `self.format_cr`, siguiendo el patrón de acceso directo a MongoDB ya usado en el módulo.
- La creación sigue el patrón estándar de `post_forms_answers` con `get_metadata` + `device_properties`, alineado con las guías del proyecto.